### PR TITLE
logging.warn -> logging.warning (Depreciated function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Author | [char(30)]
 
 If you do not want to save pastes, set USE_DB to False
 
-## Executing pastebin_scraper
+## Executing pastebin_scraper (REQUIRES PASTEBIN PRO ACCOUNT)
         python3 pastebin_scraper.py
 
 ## Disclaimer

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -12,9 +12,9 @@ def download(url, headers=None):
     try:
         response = r.get(url).text
     except requests.ConnectionError:
-        logging.warn('[!] Critical Error - Cannot connect to site')
+        logging.warning('[!] Critical Error - Cannot connect to site')
         sleep(5)
-        logging.warn('[!] Retrying...')
+        logging.warning('[!] Retrying...')
         response = download(url)
     return response
 

--- a/pastebin_scraper.py
+++ b/pastebin_scraper.py
@@ -52,7 +52,7 @@ def monitor():
         while(1):
             sleep(5)
     except KeyboardInterrupt:
-        logging.warn('Stopped.')
+        logging.warning('Stopped.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is based on the following output i received when interrupted with ^C.

```
pastebin_scraper.py:55: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
logging.warn('Stopped.')
```